### PR TITLE
[0.10.0] remove pandas dep

### DIFF
--- a/lib/requirements.txt
+++ b/lib/requirements.txt
@@ -3,4 +3,3 @@ colorama>=0.3.0
 ipynbname==2021.3.2
 langchain==0.0.118
 openai==0.27.*
-pandas>=1.3.0

--- a/lib/roboduck/__init__.py
+++ b/lib/roboduck/__init__.py
@@ -7,7 +7,7 @@ from roboduck.ipy_utils import is_colab
 from roboduck.utils import available_models
 
 
-__version__ = '0.9.0'
+__version__ = '0.10.0'
 set_openai_api_key()
 if is_colab():
     warnings.warn(

--- a/lib/roboduck/debug.py
+++ b/lib/roboduck/debug.py
@@ -135,7 +135,7 @@ class DuckDB(Pdb):
     library).
     """
 
-    def __init__(self, prompt_name='debug', max_len_per_var=79, silent=False,
+    def __init__(self, prompt_name='debug', max_len_per_var=400, silent=False,
                  pdb_kwargs=None, parse_func=parse_completion, color='green',
                  **chat_kwargs):
         """
@@ -159,9 +159,9 @@ class DuckDB(Pdb):
             Limits number of characters per variable when communicating
             current state (local or global depending on `full_context`) to
             gpt. If unbounded, that section of the prompt alone could grow
-            very big . I somewhat arbitrarily set 79 as the default, i.e.
-            1 line of python per variable. I figure that's usually enough to
-            communicate the gist of what's happening.
+            very big. I somewhat arbitrarily set 400 as the default, i.e.
+            100 tokens. I figure that's usually enough
+            to communicate the gist of what's happening.
         silent : bool
             If True, print gpt completions to stdout. One example of when False
             is appropriate is our logging module - we want to get the

--- a/lib/roboduck/langchain/chat.py
+++ b/lib/roboduck/langchain/chat.py
@@ -327,7 +327,7 @@ class Chat:
                     f'({self.context_window:,} tokens). You could try using '
                     f'a different model_name with a larger context window, a '
                     f'prompt_name corresponding to a more concise prompt, '
-                    f'a smaller max_len_per_var (default is 79), or '
+                    f'a smaller max_len_per_var (default is 400), or '
                     f'refactoring your code (this error could potentially be '
                     f'caused by a truly enormous function).'
                 )

--- a/lib/roboduck/utils.py
+++ b/lib/roboduck/utils.py
@@ -313,8 +313,6 @@ def truncated_repr(obj, max_len=400) -> str:
                 truncated_data=truncated_str
             )
 
-        repr_ = truncated_repr(slice_, max_len)
-
         return format_listlike_with_metadata(obj, truncated_data=slice_)
 
     # We know it's non-iterable at this point.

--- a/lib/roboduck/utils.py
+++ b/lib/roboduck/utils.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterable
 from colorama import Fore, Style
 import difflib
+from functools import wraps
 import openai
 import os
 from pathlib import Path
@@ -218,6 +219,7 @@ def fallback(*, default=None, default_func=None):
                          'must be non-None.')
 
     def decorator(func):
+        @wraps(func)
         def wrapper(*args, **kwargs):
             try:
                 return func(*args, **kwargs)
@@ -272,24 +274,15 @@ def truncated_repr(obj, max_len=400) -> str:
         cols = truncated_repr(obj.columns.tolist(), max_len - 26)
         return f'pd.DataFrame(columns=' \
                f'{truncated_repr(cols, max_len - 22)}, shape={obj.shape})'
-    if is_pandas_series(obj):
-        return f'pd.Series({truncated_repr(obj.tolist(), max_len - 11)})'
+
     # TODO rm
-    # if isinstance(obj, dict):
-    #     length = 5
-    #     res = ''
-    #     for k, v in obj.items():
-    #         if length >= max_len - 2:
-    #             break
-    #         new_str = f'{k!r}: {v!r}, '
-    #         length += len(new_str)
-    #         res += new_str
-    #     return f"<{qualname(obj, with_brackets=False)}, " + \
-    #            "truncated_data={" + res.rstrip() + \
-    #            "...}, " + f"len={len(obj)}" + ">"
+    print('no more series custom logic')
+    # if is_pandas_series(obj):
+        # return f'pd.Series({truncated_repr(obj.tolist(), max_len - 11)})'
 
     if isinstance(obj, str):
         return repr_[:max_len - 4] + "...'"
+    print('not str') # TODO rm
 
     # TODO: see if we can replace this with simliar logic (or refactor to use
     # same logic) as dict block above. The recursive call makes it a little
@@ -310,6 +303,7 @@ def truncated_repr(obj, max_len=400) -> str:
         # bulletproof (usually only a problem for nested or multidimensional
         # data structures).
         n = max(1, int(max_len / len(repr_) * len(obj)))
+        print('n', n) # TODO rm
         if n == len(obj):
             # Even slicing to just first item is too long, so just revert
             # to treating this like a non-iterable object.
@@ -324,6 +318,8 @@ def truncated_repr(obj, max_len=400) -> str:
             slice_ = obj[:n]
 
         repr_ = truncated_repr(slice_, max_len)
+        # TODO rm
+        print('slice repr', repr_)
         # TODO: rm? I think this is good if we're in an inner call but bad if
         # this is the outer call.
         # Don't add any ellipses in this case.

--- a/lib/roboduck/utils.py
+++ b/lib/roboduck/utils.py
@@ -160,7 +160,36 @@ def qualname(obj, with_brackets=True) -> str:
 
 
 def format_listlike_with_metadata(array, truncated_data=None):
-    """
+    """Format a list-like object with metadata.
+
+    This function creates a string representation of a list-like object,
+    including its class name, truncated data (if provided), and additional
+    metadata such as shape, dtype, or length.
+
+    Parameters
+    ----------
+    array : object
+        The list-like object to be formatted.
+    truncated_data : object, optional
+        A truncated version of the array's data. If provided, it will be
+        included in the formatted string.
+
+    Returns
+    -------
+    str
+        A formatted string representation of the array with metadata.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> arr = np.array([1, 2, 3, 4, 5])
+    >>> format_listlike_with_metadata(arr, arr[:3])
+    '<numpy.ndarray, truncated_data=[1, 2, 3, ...], shape=(5,), dtype=int64>'
+
+    >>> import pandas as pd
+    >>> series = pd.Series(['a', 'b', 'c', 'd', 'e'])
+    >>> format_listlike_with_metadata(series, series[:2])
+    "<pandas.core.series.Series, truncated_data=['a', 'b', ...], len=5>"
     """
     clsname = qualname(array, with_brackets=False)
     res = f"<{clsname}, "
@@ -222,7 +251,7 @@ def truncated_repr(obj, max_len=400) -> str:
     if is_pandas_df(obj):
         cols = truncated_repr(obj.columns.tolist(), max_len - 26)
         return f'pd.DataFrame(columns=' \
-               f'{truncated_repr(cols, max_len - 22)})'
+               f'{truncated_repr(cols, max_len - 22)}, shape={obj.shape})'
     if is_pandas_series(obj):
         return f'pd.Series({truncated_repr(obj.tolist(), max_len - 11)})'
     if isinstance(obj, dict):

--- a/lib/roboduck/utils.py
+++ b/lib/roboduck/utils.py
@@ -121,19 +121,6 @@ def is_pandas_df(obj) -> bool:
     )
 
 
-def is_pandas_series(obj) -> bool:
-    """Slightly hacky replacement for isinstance(obj, pd.Series)
-    to avoid requiring a pandas dependency solely for a couple isinstance
-    checks. Not ideal but I think it's better than the alternative.
-    """
-    clsname = getattr(type(obj), "__qualname__", "")
-    return clsname == "Series" \
-        and all(
-            hasattr(obj, name)
-            for name in ("sort_values", "value_counts", "iloc")
-    )
-
-
 def is_array_like(obj) -> bool:
     """Similar to is_pandas_df but for numpy arrays/torch tensors/similar.
     Instead of checking for specific types here, we just check that the obj
@@ -274,11 +261,6 @@ def truncated_repr(obj, max_len=400) -> str:
         cols = truncated_repr(obj.columns.tolist(), max_len - 26)
         return f'pd.DataFrame(columns=' \
                f'{truncated_repr(cols, max_len - 22)}, shape={obj.shape})'
-
-    # TODO rm
-    print('no more series custom logic')
-    # if is_pandas_series(obj):
-        # return f'pd.Series({truncated_repr(obj.tolist(), max_len - 11)})'
 
     if isinstance(obj, str):
         return repr_[:max_len - 4] + "...'"

--- a/lib/roboduck/utils.py
+++ b/lib/roboduck/utils.py
@@ -113,9 +113,8 @@ def is_pandas_df(obj) -> bool:
     to avoid requiring a pandas dependency solely for a couple isinstance
     checks. Not ideal but I think it's better than the alternative.
     """
-    clsname = str(type(obj))
-    return clsname.startswith("pandas") \
-        and clsname.endswith("DataFrame") \
+    clsname = getattr(type(obj), "__qualname__", "")
+    return clsname == "DataFrame" \
         and all(
             hasattr(obj, name)
             for name in ("columns", "value_counts", "iloc")
@@ -127,9 +126,8 @@ def is_pandas_series(obj) -> bool:
     to avoid requiring a pandas dependency solely for a couple isinstance
     checks. Not ideal but I think it's better than the alternative.
     """
-    clsname = str(type(obj))
-    return clsname.startswith("pandas") \
-        and clsname.endswith("Series") \
+    clsname = getattr(type(obj), "__qualname__", "")
+    return clsname == "Series" \
         and all(
             hasattr(obj, name)
             for name in ("sort_values", "value_counts", "iloc")

--- a/lib/roboduck/utils.py
+++ b/lib/roboduck/utils.py
@@ -193,16 +193,17 @@ def format_listlike_with_metadata(array, truncated_data=None):
     """
     clsname = qualname(array, with_brackets=False)
     res = f"<{clsname}, "
+    if truncated_data is None:
+        truncated_data = '[...]'
+
     if is_array_like(array):
-        if truncated_data is not None:
-            repr_ = repr(truncated_data.tolist())
-            res += f"truncated_data={repr_[:-1]}, ...{repr_[-1]}, "
+        repr_ = repr(truncated_data.tolist())
+        res += f"truncated_data={repr_[:-1]}, ...{repr_[-1]}, "
         res += f"shape={array.shape}, dtype={array.dtype}>"
         return res
 
-    if truncated_data is not None:
-        repr_ = repr(truncated_data)
-        res += f"truncated_data={repr_[:-1]}, ...{repr_[-1]}, "
+    repr_ = repr(truncated_data)
+    res += f"truncated_data={repr_[:-1]}, ...{repr_[-1]}, "
     return res + f"len={len(array)}>"
 
 
@@ -236,7 +237,6 @@ def truncated_repr(obj, max_len=400) -> str:
         deal, at least at the moment. I can always revisit that later if
         necessary.
     """
-
     open2close = {
         '[': ']',
         '(': ')',
@@ -301,9 +301,11 @@ def truncated_repr(obj, max_len=400) -> str:
             try:
                 slice_ = obj[:n]
             except Exception as e:
-                warnings.warn(f'Failed to slice obj {obj}. Result may not be '
-                              f'truncated as much as desired. Error:\n{e}')
-                slice_ = obj
+                warnings.warn(
+                    f'Failed to slice obj {obj}, returning qualname. '
+                    f'Error:\n{e}'
+                )
+                return qualname(obj)
 
         repr_ = truncated_repr(slice_, max_len)
         # TODO: rm? I think this is good if we're in an inner call but bad if

--- a/lib/roboduck/utils.py
+++ b/lib/roboduck/utils.py
@@ -299,21 +299,21 @@ def truncated_repr(obj, max_len=400) -> str:
         if n == len(obj):
             # Slicing didn't help in this case so do some manual surgery.
             # Don't call truncated_repr recursively here because we would
-            # get stuck in an infinite loop.
-            # TODO: subtracted 10 as a placeholder, could be more careful or just
-            # ignore precision entirely.
-            print('in n=len(obj)')
+            # get stuck in an infinite loop because there's no room to slice
+            # our object to be shorter.
+            # Arbitrarily choosing to subtract 10 to account for some the
+            # characters created by qualname and attributres, could try to do
+            # this more carefully but don't think it's worth it right now.
+            # We then slice up to the last comma to ensure we don't truncate
+            # mid item, e.g. [10, 20, 30] should not be truncated to '[10, 2'.
+            truncated_str = repr(slice_)[:max_len - 10]
+            truncated_str = truncated_str[:truncated_str.rfind(',')]
             return format_listlike_with_metadata(
                 obj,
-                truncated_data=repr(slice_)[:max_len - 10].rstrip(', ')
+                truncated_data=truncated_str
             )
 
         repr_ = truncated_repr(slice_, max_len)
-        # TODO: rm? I think this is good if we're in an inner call but bad if
-        # this is the outer call.
-        # Don't add any ellipses in this case.
-        # if repr_ == qualname(obj):
-        #     return repr_
 
         return format_listlike_with_metadata(obj, truncated_data=slice_)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+pandas>=1.3.0
 pydocstyle
 pytest
 -e ./lib

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -158,23 +158,6 @@ def test_store_class_defaults():
     "obj,answer",
     (
         ({3: 4}, False),
-        ([2], False),
-        (('a', 'b', 'c'), False),
-        ('pandas.DataFrame', False),
-        (pd.DataFrame, False),
-        (pd.Series([1, 2, 3]), False),
-        (pd.DataFrame({"a": [3, 5]}), True),
-        (pd.DataFrame(), True),
-    )
-)
-def test_is_pandas_df(obj, answer):
-    assert utils.is_pandas_df(obj) == answer
-
-
-@pytest.mark.parametrize(
-    "obj,answer",
-    (
-        ({3: 4}, False),
         ([2, 3], False),
         ([], False),
         (('a', 'b', 'c'), False),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,16 +26,15 @@ def test_truncated_repr_short_inputs(obj):
     [
         (list(range(1000)),
          50,
-         "[0, 1, 2, 3, 4, 5, 6, 7, 8, 9,...]"),
+         "<list, truncated_data=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...], len=1000>"),
         (pd.DataFrame(np.arange(390).reshape(30, 13),
                       columns=list('abcdefghijklm')),
          79,
-         "pd.DataFrame(columns=\"['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h',"
-         " 'i', 'j',...]\")"),
-        ("abcdefghijklmnopqrstuvwxyz", 20, "'abcdefghijklmno...'"),
+         '<pandas.core.frame.DataFrame, truncated_data=   a  b  c  d  e  f  g  h  i  j   k   l   m\n0  0  1  2  3  4  5  6  7  8  9  10  11  12, ..., len=30>'),
+        ("abcdefghijklmnopqrstuvwxyz", 21, "'abcd...' (truncated)"),
         (dict(enumerate('abcdefghijklmnop')),
          50,
-         "{0: 'a', 1: 'b', 2: 'c', 3: 'd', 4: 'e', 5: 'f',...}")
+         "<dict, truncated_data=[(0, 'a'), (1, 'b'), (2, 'c'), (3, 'd'), (4, 'e'), ...], len=16>"),
     ]
 )
 def test_truncated_repr_long_inputs(obj, n, expected):
@@ -57,7 +56,7 @@ def test_truncated_repr_long_inputs(obj, n, expected):
         ),
         (
             [{'a': 1, 'b': 2}, {'c': 3, 'd': 4}, {'e': 5, 'f': 6}],
-            50,
+            60,
             "[{'a': 1, 'b': 2}, {'c': 3, 'd': 4}, {'e': 5, 'f': 6}]"
         ),
         (
@@ -66,10 +65,9 @@ def test_truncated_repr_long_inputs(obj, n, expected):
             "<list, truncated_data=[{'a': 1, 'b': 2}, ...], len=3>"
         ),
         (
-            {'x': list(range(100 * i)) for i in range(10)},
+            {i: list(range(100 * i)) for i in range(1, 10)},
             30,
-            # TODO: fix the bug this revealed, currently I think this always
-            # displays the whole first value so repr is way too long.
+            '<dict, truncated_data=[(1, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99]), ...], len=9>',
         )
     ]
 )
@@ -166,12 +164,9 @@ def test_store_class_defaults():
         (pd.Series, False),
         (pd.DataFrame({"a": [3, 5]}), False),
         (pd.DataFrame(), False),
-        # TODO: series currently return True, consider making func stricter
-        # OR maybe removing hardcoded series if block and refactor so
-        # existing is_array_like block handles it?
-        (pd.Series([1, 2, 3]), False),
-        (pd.Series([1.0, None]), False),
-        (pd.Series(), False),
+        (pd.Series([1, 2, 3]), True),
+        (pd.Series([1.0, None]), True),
+        (pd.Series(), True),
         (np.arange(5), True),
         (np.array([]), True),
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -180,3 +180,22 @@ def test_is_pandas_series(obj, answer):
 )
 def test_is_array_like(obj, answer):
     assert utils.is_array_like(obj) == answer
+
+
+@pytest.mark.parametrize(
+    "obj,with_brackets,expected",
+    [
+        (pd.DataFrame(), False, "pandas.core.frame.DataFrame"),
+        (pd.Series(), False, "pandas.core.series.Series"),
+        (np.array([]), False, "numpy.ndarray"),
+        ([], False, "list"),
+        ({}, False, "dict"),
+        (pd.DataFrame(), True, "<pandas.core.frame.DataFrame>"),
+        (pd.Series(), True, "<pandas.core.series.Series>"),
+        (np.array([]), True, "<numpy.ndarray>"),
+        ([], True, "<list>"),
+        ({}, True, "<dict>"),
+    ]
+)
+def test_qualname(obj, with_brackets, expected):
+    assert utils.qualname(obj, with_brackets=with_brackets) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -117,3 +117,40 @@ def test_store_class_defaults():
     assert Foo.last_bar == 3
     assert Foo.last_baz == 'abc'
     assert Foo.other is False
+
+
+@pytest.mark.parametrize(
+    "obj,answer",
+    (
+        ({3: 4}, False),
+        ([2], False),
+        (('a', 'b', 'c'), False),
+        ('pandas.DataFrame', False),
+        (pd.DataFrame, False),
+        (pd.Series([1, 2, 3]), False),
+        (pd.DataFrame({"a": [3, 5]}), True),
+        (pd.DataFrame(), True),
+    )
+)
+def test_is_pandas_df(obj, answer):
+    assert utils.is_pandas_df(obj) == answer
+
+
+@pytest.mark.parametrize(
+    "obj,answer",
+    (
+        ({3: 4}, False),
+        ([2], False),
+        (('a', 'b', 'c'), False),
+        ('pandas.Series', False),
+        (pd.DataFrame, False),
+        (pd.Series, False),
+        (pd.DataFrame({"a": [3, 5]}), False),
+        (pd.DataFrame(), False),
+        (pd.Series([1, 2, 3]), True),
+        (pd.Series([1.0, None]), True),
+        (pd.Series(), True),
+    )
+)
+def test_is_pandas_series(obj, answer):
+    assert utils.is_pandas_series(obj) == answer

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -154,3 +154,29 @@ def test_is_pandas_df(obj, answer):
 )
 def test_is_pandas_series(obj, answer):
     assert utils.is_pandas_series(obj) == answer
+
+
+@pytest.mark.parametrize(
+    "obj,answer",
+    (
+        ({3: 4}, False),
+        ([2, 3], False),
+        ([], False),
+        (('a', 'b', 'c'), False),
+        ('pandas.Series', False),
+        (pd.DataFrame, False),
+        (pd.Series, False),
+        (pd.DataFrame({"a": [3, 5]}), False),
+        (pd.DataFrame(), False),
+        # TODO: series currently return True, consider making func stricter
+        # OR maybe removing hardcoded series if block and refactor so
+        # existing is_array_like block handles it?
+        (pd.Series([1, 2, 3]), False),
+        (pd.Series([1.0, None]), False),
+        (pd.Series(), False),
+        (np.arange(5), True),
+        (np.array([]), True),
+    )
+)
+def test_is_array_like(obj, answer):
+    assert utils.is_array_like(obj) == answer

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -175,26 +175,6 @@ def test_is_pandas_df(obj, answer):
     "obj,answer",
     (
         ({3: 4}, False),
-        ([2], False),
-        (('a', 'b', 'c'), False),
-        ('pandas.Series', False),
-        (pd.DataFrame, False),
-        (pd.Series, False),
-        (pd.DataFrame({"a": [3, 5]}), False),
-        (pd.DataFrame(), False),
-        (pd.Series([1, 2, 3]), True),
-        (pd.Series([1.0, None]), True),
-        (pd.Series(), True),
-    )
-)
-def test_is_pandas_series(obj, answer):
-    assert utils.is_pandas_series(obj) == answer
-
-
-@pytest.mark.parametrize(
-    "obj,answer",
-    (
-        ({3: 4}, False),
         ([2, 3], False),
         ([], False),
         (('a', 'b', 'c'), False),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -43,6 +43,41 @@ def test_truncated_repr_long_inputs(obj, n, expected):
 
 
 @pytest.mark.parametrize(
+    'obj, n, expected',
+    [
+        (
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            50,
+            "[[1, 2, 3], [4, 5, 6], [7, 8, 9]]"
+        ),
+        (
+            [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]],
+            40,
+            "<list, truncated_data=[[1, 2, 3], [4, 5, 6], [7, 8, 9], ...], len=4>"
+        ),
+        (
+            [{'a': 1, 'b': 2}, {'c': 3, 'd': 4}, {'e': 5, 'f': 6}],
+            50,
+            "[{'a': 1, 'b': 2}, {'c': 3, 'd': 4}, {'e': 5, 'f': 6}]"
+        ),
+        (
+            [{'a': 1, 'b': 2}, {'c': 3, 'd': 4}, {'e': 5, 'f': 6}],
+            30,
+            "<list, truncated_data=[{'a': 1, 'b': 2}, ...], len=3>"
+        ),
+        (
+            {'x': list(range(100 * i)) for i in range(10)},
+            30,
+            # TODO: fix the bug this revealed, currently I think this always
+            # displays the whole first value so repr is way too long.
+        )
+    ]
+)
+def test_truncated_repr_nested_inputs(obj, n, expected):
+    assert utils.truncated_repr(obj, n) == expected
+
+
+@pytest.mark.parametrize(
     "d, func, expected",
     [
         ({}, repr, '{\n}'),


### PR DESCRIPTION
# Change Summary
- remove pandas dependency (now in dev requirements for testing)
- increased default max repr length per object from 79 to 400 due to recent increases in context windows
- revised truncated_repr func a bit to better handle nested data structures, dicts with long first item, customer iterables